### PR TITLE
remove value from payment-info-update endpoints

### DIFF
--- a/src/Treasury/Communicator.php
+++ b/src/Treasury/Communicator.php
@@ -259,7 +259,6 @@ class Communicator extends BasicCommunicator
         $response = $this->request(static::METHOD_POST, $uri, [
              'payment_info_id' => $paymentInfoUpdateDto->getPaymentInfoId(),
              'creator_id'   => $paymentInfoUpdateDto->getCreatorId(),
-             'value' => $paymentInfoUpdateDto->getValue(),
              'action' => $paymentInfoUpdateDto->getAction(),
         ]);
 

--- a/src/Treasury/Dto/PaymentInfoUpdateDto.php
+++ b/src/Treasury/Dto/PaymentInfoUpdateDto.php
@@ -19,9 +19,6 @@ class PaymentInfoUpdateDto
     /** @var int */
     private $creatorId;
 
-    /** @var int */
-    private $value;
-
     /** @var string */
     private $action;
 
@@ -43,16 +40,6 @@ class PaymentInfoUpdateDto
     public function setCreatorId(int $creatorId): void
     {
         $this->creatorId = $creatorId;
-    }
-
-    public function getValue(): int
-    {
-        return $this->value;
-    }
-
-    public function setValue(int $value): void
-    {
-        $this->value = $value;
     }
 
     public function setAction(string $action): void


### PR DESCRIPTION
This pull request will:
* remove 'value' parameter from the body of payment info update endpoint
